### PR TITLE
Try out approach to not consuming blueprint ingredient

### DIFF
--- a/src/main/java/com/pjht/mesystem/item/crafting/BlueprintRecipeFactory.java
+++ b/src/main/java/com/pjht/mesystem/item/crafting/BlueprintRecipeFactory.java
@@ -1,0 +1,37 @@
+package com.pjht.mesystem.item.crafting;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.JsonUtils;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.crafting.CraftingHelper;
+import net.minecraftforge.common.crafting.IRecipeFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+
+public class BlueprintRecipeFactory implements IRecipeFactory {
+
+    public BlueprintRecipeFactory() {}
+
+    @Override
+    public IRecipe parse(JsonContext context, JsonObject json) {
+        String group = JsonUtils.getString(json, "group", "");
+
+        NonNullList<Ingredient> ings = NonNullList.create();
+        for (JsonElement ele : JsonUtils.getJsonArray(json, "ingredients"))
+            ings.add(CraftingHelper.getIngredient(ele, context));
+
+        if (ings.isEmpty())
+            throw new JsonParseException("No ingredients for blueprint shapeless recipe");
+        if (ings.size() > 9)
+            throw new JsonParseException("Too many ingredients for blueprint shapeless recipe");
+
+        ItemStack itemstack = CraftingHelper.getItemStack(JsonUtils.getJsonObject(json, "result"), context);
+        return new BlueprintShapelessRecipe(group, itemstack, ings);
+    }
+
+}

--- a/src/main/java/com/pjht/mesystem/item/crafting/BlueprintShapelessRecipe.java
+++ b/src/main/java/com/pjht/mesystem/item/crafting/BlueprintShapelessRecipe.java
@@ -1,0 +1,31 @@
+package com.pjht.mesystem.item.crafting;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.ForgeHooks;
+
+public class BlueprintShapelessRecipe extends ShapelessRecipes {
+
+    public BlueprintShapelessRecipe(String group, ItemStack output, NonNullList<Ingredient> ingredients) {
+        super(group, output, ingredients);
+    }
+
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
+        NonNullList<ItemStack> nonnulllist = NonNullList.<ItemStack>withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+
+        for (int i = 0; i < nonnulllist.size(); ++i)
+        {
+            ItemStack itemstack = inv.getStackInSlot(i);
+            if (itemstack.getItem().getUnlocalizedName().equals("8080_blueprint")) {
+                nonnulllist.set(i, ForgeHooks.getContainerItem(itemstack));
+            }
+        }
+
+        return nonnulllist;
+    }
+
+}

--- a/src/main/resources/assets/mesystem/recipes/8080_chip.json
+++ b/src/main/resources/assets/mesystem/recipes/8080_chip.json
@@ -1,5 +1,5 @@
 {
-	"type": "minecraft:crafting_shapeless",
+	"type": "mesystem:blueprint_shapeless",
 	"ingredients": [
 		{
 			"item": "ssspcore:blank_chip"

--- a/src/main/resources/assets/mesystem/recipes/_factories.json
+++ b/src/main/resources/assets/mesystem/recipes/_factories.json
@@ -1,0 +1,5 @@
+{
+	"recipes": {
+		"blueprint_shapeless" : "com.pjht.mysystem.item.crafting.BlueprintShapelessRecipe"
+	}
+}


### PR DESCRIPTION
So this doesn't seem to be working right now.

When I try to combine the ingredients (8080_blueprint and blank chip) at a crafting table no output is created. Not sure what's going on, but this might be a starting place.

I also posted on the Forge forums to try to get some help with this. We'll see if anyone responds.